### PR TITLE
Minor: Fix 500 Error when pagination/url is null

### DIFF
--- a/Classes/Utility/Task/ImportTaskUtility.php
+++ b/Classes/Utility/Task/ImportTaskUtility.php
@@ -190,7 +190,7 @@ class ImportTaskUtility
                         );
 
                         $data = json_decode(GeneralUtility::getUrl($url), true);
-                        
+
                         if (is_array($data)) {
                             $this->updateYoutubeFeed($data['items'], $configuration);
                         } else {
@@ -573,6 +573,9 @@ class ImportTaskUtility
 
         // Make few api calls (up to $maxRuns) and get the feed
         for ($i = 0; $i < $maxRuns; $i++) {
+            if (!$url) {
+                break;
+            }
             $data = $this->getInstagramFeedResponse($url);
             $feedItems = array_merge($feedItems, $data['feed']);
             if (count($feedItems) >= $limit) {


### PR DESCRIPTION
Instagram feed pagination url is null when no more pages exists. This is causing a 500 Error on the importer.
I did a fast fix for it.
It would be great if you could release it as soon as possible.