### PR TITLE
add run_all_configurations checkbox as a scheduler setting

### DIFF
--- a/Classes/Service/Task/ImportFeedsTaskService.php
+++ b/Classes/Service/Task/ImportFeedsTaskService.php
@@ -61,8 +61,13 @@ class ImportFeedsTaskService
      */
     public function import(array $configurationUids, bool $runAllConfigurations = false): bool
     {
-        /** @var Configuration[] $configurations */
-        $configurations = $runAllConfigurations ? $this->configurationRepository->findAll() : $this->configurationRepository->findByUids($configurationUids);
+        if ($runAllConfigurations) {
+            /** @var Configuration[] $configurations */
+            $configurations = $this->configurationRepository->findAll();
+        } else {
+            /** @var Configuration[] $configurations */
+            $configurations = $this->configurationRepository->findByUids($configurationUids);
+        }
 
         foreach ($configurations as $configuration) {
             // Reset

--- a/Classes/Service/Task/ImportFeedsTaskService.php
+++ b/Classes/Service/Task/ImportFeedsTaskService.php
@@ -56,12 +56,13 @@ class ImportFeedsTaskService
      * Import logic
      *
      * @param array $configurationUids
+     * @param bool $runAllConfigurations
      * @return bool
      */
-    public function import(array $configurationUids): bool
+    public function import(array $configurationUids, bool $runAllConfigurations = false): bool
     {
         /** @var Configuration[] $configurations */
-        $configurations = $this->configurationRepository->findByUids($configurationUids);
+        $configurations = $runAllConfigurations ? $this->configurationRepository->findAll() : $this->configurationRepository->findByUids($configurationUids);
 
         foreach ($configurations as $configuration) {
             // Reset

--- a/Classes/Task/ImportTask.php
+++ b/Classes/Task/ImportTask.php
@@ -60,6 +60,11 @@ class ImportTask extends AbstractTask
     protected $senderEmail = '';
 
     /**
+     * @var bool
+     */
+    protected $runAllConfigurations = false;
+
+    /**
      * Execute scheduler task
      *
      * @return bool
@@ -70,7 +75,7 @@ class ImportTask extends AbstractTask
         $importTaskService = GeneralUtility::makeInstance(ImportFeedsTaskService::class, $notificationService);
 
         try {
-            return $importTaskService->import($this->configurations);
+            return $importTaskService->import($this->configurations, $this->runAllConfigurations);
         } catch (\Exception $exception) {
             LoggerUtility::log(
                 $exception->getMessage(),
@@ -100,7 +105,10 @@ class ImportTask extends AbstractTask
      */
     public function getAdditionalInformation(): string
     {
-        return SchedulerUtility::getSelectedConfigurationsInfo($this->getConfigurations());
+        return SchedulerUtility::getSelectedConfigurationsInfo(
+            $this->getConfigurations(),
+            $this->isRunAllConfigurations()
+        );
     }
 
     /**
@@ -158,5 +166,21 @@ class ImportTask extends AbstractTask
     {
         $sender = $this->senderEmail ?: $GLOBALS['TYPO3_CONF_VARS']['MAIL']['defaultMailFromAddress'];
         return GeneralUtility::makeInstance(NotificationService::class, $this->receiverEmail, $sender);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isRunAllConfigurations(): bool
+    {
+        return $this->runAllConfigurations;
+    }
+
+    /**
+     * @param bool $runAllConfigurations
+     */
+    public function setRunAllConfigurations(bool $runAllConfigurations): void
+    {
+        $this->runAllConfigurations = $runAllConfigurations;
     }
 }

--- a/Classes/Task/ImportTaskAdditionalFieldProvider.php
+++ b/Classes/Task/ImportTaskAdditionalFieldProvider.php
@@ -56,17 +56,19 @@ class ImportTaskAdditionalFieldProvider implements AdditionalFieldProviderInterf
             $taskInfo['pxasocialfeed_configs'] = null;
             $taskInfo['pxasocialfeed_receiver_email'] = '';
             $taskInfo['pxasocialfeed_sender_email'] = '';
+            $taskInfo['pxasocialfeed_run_all_configs'] = false;
         }
 
         if ($this->getAction($parentObject) == 'edit') {
             $taskInfo['pxasocialfeed_configs'] = $task->getConfigurations();
             $taskInfo['pxasocialfeed_receiver_email'] = $task->getReceiverEmail();
             $taskInfo['pxasocialfeed_sender_email'] = $task->getSenderEmail();
+            $taskInfo['pxasocialfeed_run_all_configs'] = $task->isRunAllConfigurations();
         }
 
         $additionalFields['pxasocialfeed_run_all_configs'] = [
             'code' => '<input type="checkbox" name="tx_scheduler[pxasocialfeed_run_all_configs]" '
-                . ($task->isRunAllConfigurations() ? 'checked="checked"' : '') . ' />',
+                . ($taskInfo['pxasocialfeed_run_all_configs'] ? 'checked="checked"' : '') . ' />',
             'label' => 'LLL:EXT:pxa_social_feed/Resources/Private/Language/locallang_be.xlf:scheduler.run_all_configs',
             'cshKey' => '',
             'cshLabel' => '',

--- a/Classes/Task/ImportTaskAdditionalFieldProvider.php
+++ b/Classes/Task/ImportTaskAdditionalFieldProvider.php
@@ -65,7 +65,8 @@ class ImportTaskAdditionalFieldProvider implements AdditionalFieldProviderInterf
         }
 
         $additionalFields['pxasocialfeed_run_all_configs'] = [
-            'code' => '<input type="checkbox" name="tx_scheduler[pxasocialfeed_run_all_configs]" ' . ($task->isRunAllConfigurations() ? 'checked="checked"' : '') . ' />',
+            'code' => '<input type="checkbox" name="tx_scheduler[pxasocialfeed_run_all_configs]" '
+                . ($task->isRunAllConfigurations() ? 'checked="checked"' : '') . ' />',
             'label' => 'LLL:EXT:pxa_social_feed/Resources/Private/Language/locallang_be.xlf:scheduler.run_all_configs',
             'cshKey' => '',
             'cshLabel' => '',
@@ -107,7 +108,9 @@ class ImportTaskAdditionalFieldProvider implements AdditionalFieldProviderInterf
         // nothing to validate, just list of uids
         $valid = false;
 
-        if (!isset($submittedData['pxasocialfeed_run_all_configs']) && !isset($submittedData['pxasocialfeed_configs'])) {
+        if (!isset($submittedData['pxasocialfeed_run_all_configs'])
+            && !isset($submittedData['pxasocialfeed_configs'])
+        ) {
             $this->addMessage('Wrong configurations select', FlashMessage::ERROR);
         } elseif (!$this->isValidEmail($submittedData['pxasocialfeed_sender_email'])
             || !$this->isValidEmail($submittedData['pxasocialfeed_receiver_email'])

--- a/Classes/Task/ImportTaskAdditionalFieldProvider.php
+++ b/Classes/Task/ImportTaskAdditionalFieldProvider.php
@@ -64,6 +64,13 @@ class ImportTaskAdditionalFieldProvider implements AdditionalFieldProviderInterf
             $taskInfo['pxasocialfeed_sender_email'] = $task->getSenderEmail();
         }
 
+        $additionalFields['pxasocialfeed_run_all_configs'] = [
+            'code' => '<input type="checkbox" name="tx_scheduler[pxasocialfeed_run_all_configs]" ' . ($task->isRunAllConfigurations() ? 'checked="checked"' : '') . ' />',
+            'label' => 'LLL:EXT:pxa_social_feed/Resources/Private/Language/locallang_be.xlf:scheduler.run_all_configs',
+            'cshKey' => '',
+            'cshLabel' => '',
+        ];
+
         $additionalFields['pxasocialfeed_configs'] = [
             'code' => SchedulerUtility::getAvailableConfigurationsSelectBox($taskInfo['pxasocialfeed_configs'] ?? []),
             'label' => 'LLL:EXT:pxa_social_feed/Resources/Private/Language/locallang_be.xlf:scheduler.configs',
@@ -100,7 +107,7 @@ class ImportTaskAdditionalFieldProvider implements AdditionalFieldProviderInterf
         // nothing to validate, just list of uids
         $valid = false;
 
-        if (!isset($submittedData['pxasocialfeed_configs'])) {
+        if (!isset($submittedData['pxasocialfeed_run_all_configs']) && !isset($submittedData['pxasocialfeed_configs'])) {
             $this->addMessage('Wrong configurations select', FlashMessage::ERROR);
         } elseif (!$this->isValidEmail($submittedData['pxasocialfeed_sender_email'])
             || !$this->isValidEmail($submittedData['pxasocialfeed_receiver_email'])
@@ -119,9 +126,10 @@ class ImportTaskAdditionalFieldProvider implements AdditionalFieldProviderInterf
      */
     public function saveAdditionalFields(array $submittedData, AbstractTask $task)
     {
-        $task->setConfigurations($submittedData['pxasocialfeed_configs']);
+        $task->setConfigurations($submittedData['pxasocialfeed_configs'] ?? []);
         $task->setReceiverEmail($submittedData['pxasocialfeed_receiver_email']);
         $task->setSenderEmail($submittedData['pxasocialfeed_sender_email']);
+        $task->setRunAllConfigurations((bool) $submittedData['pxasocialfeed_run_all_configs']);
     }
 
     /**

--- a/Classes/Utility/SchedulerUtility.php
+++ b/Classes/Utility/SchedulerUtility.php
@@ -75,10 +75,15 @@ class SchedulerUtility
 
     /**
      * @param array $configurations
+     * @param bool $runAllConfigurations
      * @return string
      */
-    public static function getSelectedConfigurationsInfo(array $configurations)
+    public static function getSelectedConfigurationsInfo(array $configurations, bool $runAllConfigurations)
     {
+        if ($runAllConfigurations) {
+            return 'Feeds: All configurations';
+        }
+
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getQueryBuilderForTable('tx_pxasocialfeed_domain_model_configuration');
 

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -44,6 +44,9 @@
 			<!--Backend plguin preview:END-->
 
 			<!--Scheduler:START-->
+			<trans-unit id="scheduler.run_all_configs">
+				<source>Run all configurations (Overrides any selected configs below)</source>
+			</trans-unit>
 			<trans-unit id="scheduler.configs">
 				<source>Available configurations</source>
 			</trans-unit>


### PR DESCRIPTION
This pull request adds a checkbox to the Scheduler options named "Run all configurations".

The idea behind this checkbox is that it will override any individual configurations and instead just run them all. This means that new Social Feed configurations can be created without also having to update the scheduler.

The reason I added this feature is because I needed to create a TYPO3 account for a Facebook tester to confirm that the `pxa_social_feed` extension is doing what I say it does, but when they create their own Social Feed configuration, they can't add it to the Scheduler because I do not want to give them admin access. The end result being that they deny me the [`manage_pages`](https://developers.facebook.com/docs/facebook-login/permissions/#reference-manage_pages) permission needed to pull posts from Facebook.

Please let me know if you have any questions.