### PR TITLE
[FEATURE] Add new signal 'changedFeedItem'

### DIFF
--- a/Classes/Domain/Repository/FeedRepository.php
+++ b/Classes/Domain/Repository/FeedRepository.php
@@ -4,7 +4,6 @@ namespace Pixelant\PxaSocialFeed\Domain\Repository;
 
 use Pixelant\PxaSocialFeed\Domain\Model\Configuration;
 use Pixelant\PxaSocialFeed\Domain\Model\Feed;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\Generic\QueryResult;
 use TYPO3\CMS\Extbase\Persistence\Generic\Typo3QuerySettings;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
@@ -70,25 +69,24 @@ class FeedRepository extends Repository
     }
 
     /**
-     * Remove feed items for configuration that were not listed in object storage
+     * Finds all feed items for configuration that were not listed in object storage
      *
      * @param ObjectStorage $storage
      * @param Configuration $configuration
+     * @return \TYPO3\CMS\Extbase\Persistence\QueryResultInterface<QueryResult>
      */
-    public function removeNotInStorage(ObjectStorage $storage, Configuration $configuration): void
+    public function findNotInStorage(ObjectStorage $storage, Configuration $configuration)
     {
         $query = $this->createQuery();
 
         $query->matching(
-            $query->logicalAnd(
+            $query->logicalAnd([
                 $query->logicalNot($query->in('uid', $storage)),
                 $query->equals('configuration', $configuration)
-            )
+            ])
         );
 
-        foreach ($query->execute() as $itemToRemove) {
-            $this->remove($itemToRemove);
-        }
+        return $query->execute();
     }
 
     /**

--- a/Classes/Feed/Update/BaseUpdater.php
+++ b/Classes/Feed/Update/BaseUpdater.php
@@ -64,7 +64,7 @@ abstract class BaseUpdater implements FeedUpdaterInterface
     {
         /** @var Feed $feedToRemove */
         foreach ($this->feedRepository->findNotInStorage($this->feeds, $configuration) as $feedToRemove) {
-            $this->signalSlotDispatcher->dispatch(__CLASS__, 'changedFeedItem', [$feedToRemove]);
+            $this->getSignalSlotDispatcher()->dispatch(__CLASS__, 'changedFeedItem', [$feedToRemove]);
             $this->feedRepository->remove($feedToRemove);
         }
     }
@@ -79,7 +79,7 @@ abstract class BaseUpdater implements FeedUpdaterInterface
     {
         // Check if $feed is new or modified and emit change event
         if ($feed->_isDirty() || $feed->_isNew()) {
-            $this->signalSlotDispatcher->dispatch(__CLASS__, 'changedFeedItem', [$feed]);
+            $this->getSignalSlotDispatcher()->dispatch(__CLASS__, 'changedFeedItem', [$feed]);
         }
 
         $this->feeds->attach($feed);

--- a/Classes/Feed/Update/BaseUpdater.php
+++ b/Classes/Feed/Update/BaseUpdater.php
@@ -62,7 +62,11 @@ abstract class BaseUpdater implements FeedUpdaterInterface
      */
     public function cleanUp(Configuration $configuration): void
     {
-        $this->feedRepository->removeNotInStorage($this->feeds, $configuration);
+        /** @var Feed $feedToRemove */
+        foreach ($this->feedRepository->findNotInStorage($this->feeds, $configuration) as $feedToRemove) {
+            $this->signalSlotDispatcher->dispatch(__CLASS__, 'changedFeedItem', [$feedToRemove]);
+            $this->feedRepository->remove($feedToRemove);
+        }
     }
 
     /**
@@ -73,6 +77,11 @@ abstract class BaseUpdater implements FeedUpdaterInterface
      */
     protected function addOrUpdateFeedItem(Feed $feed): void
     {
+        // Check if $feed is new or modified and emit change event
+        if ($feed->_isDirty() || $feed->_isNew()) {
+            $this->signalSlotDispatcher->dispatch(__CLASS__, 'changedFeedItem', [$feed]);
+        }
+
         $this->feeds->attach($feed);
         $this->feedRepository->{$feed->_isNew() ? 'add' : 'update'}($feed);
     }


### PR DESCRIPTION
This signal is emitted when a feed item is created, modified or deleted.

A possible use-case of this signal is to clear a (plugin) cache if feed
items where changed. This would allow a cached list view without usage
of AJAX.