### PR TITLE
[BUGFIX] Fixes facebook access token can be too long

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -47,7 +47,7 @@ CREATE TABLE tx_pxasocialfeed_domain_model_token
     # Facebok & Instagram
     app_id              varchar(55)         DEFAULT ''  NOT NULL,
     app_secret          varchar(255)        DEFAULT ''  NOT NULL,
-    access_token        varchar(255)        DEFAULT ''  NOT NULL,
+    access_token        text                DEFAULT ''  NOT NULL,
 
     # Twitter, access_token already exist
     api_key             varchar(255)        DEFAULT ''  NOT NULL,


### PR DESCRIPTION
# New Pull Request checklist

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [x] [BUGFIX] - A bug fix
- [ ] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Description
<!-- Please add a context and reasoning around your changes, to help us merge quickly. -->
Getting an access_token from facebook with a length of more than 255 characters would lead to an error because it would be cut in database and cannot be decrypted afterwards.
According to the facebook documentation this field should better not be limited: https://developers.facebook.com/docs/facebook-login/access-tokens

> Expect that the length of all access token types will change over time as Facebook makes changes to what is stored in them and how they are encoded. You can expect that they will grow and shrink over time. Please use a variable length data type without a specific maximum size to store access tokens.

With this invalid token in the database, we cannot receive metadata of the key and not start an import since we cannot authenticate with only the first 255 characters