### PR TITLE
[BUGFIX] Avoid database error when switching type of token

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -47,7 +47,7 @@ CREATE TABLE tx_pxasocialfeed_domain_model_token
     # Facebok & Instagram
     app_id              varchar(55)         DEFAULT ''  NOT NULL,
     app_secret          varchar(255)        DEFAULT ''  NOT NULL,
-    access_token        text                DEFAULT ''  NOT NULL,
+    access_token        text,
 
     # Twitter, access_token already exist
     api_key             varchar(255)        DEFAULT ''  NOT NULL,


### PR DESCRIPTION
# New Pull Request checklist

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [x] [BUGFIX] - A bug fix
- [ ] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Description
<!-- Please add a context and reasoning around your changes, to help us merge quickly. -->

Reproduction:
- Create Token in the list view
- Switch "Type of token" to "Twitter API" (without filling fields before)

The following error is displayed:
2: SQL error: 'Field 'access_token' doesn't have a default value' (tx_pxasocialfeed_domain_model_token:NEW62f4c01209e9e253935628)

Environment:
- TYPO3 v11.5.14
- MariaDB 10.5.16
- doctrine/dbal 2.13.9