### PR TITLE
[BUGFIX] Avoid undefined array key error when saving scheduler task

### DIFF
--- a/Classes/Task/ImportTaskAdditionalFieldProvider.php
+++ b/Classes/Task/ImportTaskAdditionalFieldProvider.php
@@ -134,7 +134,7 @@ class ImportTaskAdditionalFieldProvider implements AdditionalFieldProviderInterf
         $task->setConfigurations($submittedData['pxasocialfeed_configs'] ?? []);
         $task->setReceiverEmail($submittedData['pxasocialfeed_receiver_email']);
         $task->setSenderEmail($submittedData['pxasocialfeed_sender_email']);
-        $task->setRunAllConfigurations((bool) $submittedData['pxasocialfeed_run_all_configs']);
+        $task->setRunAllConfigurations((bool) ($submittedData['pxasocialfeed_run_all_configs'] ?? false));
     }
 
     /**


### PR DESCRIPTION
# New Pull Request checklist

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [x] [BUGFIX] - A bug fix
- [ ] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Description
<!-- Please add a context and reasoning around your changes, to help us merge quickly. -->

Reproduction:
- Create a new scheduler task
- Select one available configuration und do not activate "Run all configurations"

The following error is displayed when saving the task:
PHP Warning: Undefined array key "pxasocialfeed_run_all_configs" in /var/www/html/vendor/pixelant/pxa-social-feed/Classes/Task/ImportTaskAdditionalFieldProvider.php line 137

Environment:
- TYPO3 v11.5.14
- PHP 8.1.8