### PR TITLE
[TASK] Remove outdated dividers2tab from TCA configurations

### DIFF
--- a/Configuration/TCA/tx_pxasocialfeed_domain_model_configuration.php
+++ b/Configuration/TCA/tx_pxasocialfeed_domain_model_configuration.php
@@ -12,7 +12,6 @@ return (function () {
             'tstamp' => 'tstamp',
             'crdate' => 'crdate',
             'cruser_id' => 'cruser_id',
-            'dividers2tabs' => true,
             'default_sortby' => 'crdate DESC',
 
             'delete' => 'deleted',

--- a/Configuration/TCA/tx_pxasocialfeed_domain_model_feed.php
+++ b/Configuration/TCA/tx_pxasocialfeed_domain_model_feed.php
@@ -12,7 +12,6 @@ return (function () {
             'tstamp' => 'tstamp',
             'crdate' => 'crdate',
             'cruser_id' => 'cruser_id',
-            'dividers2tabs' => true,
             'default_sortby' => 'crdate DESC',
 
             'type' => 'type',

--- a/Configuration/TCA/tx_pxasocialfeed_domain_model_token.php
+++ b/Configuration/TCA/tx_pxasocialfeed_domain_model_token.php
@@ -13,7 +13,6 @@ return (function () {
             'tstamp' => 'tstamp',
             'crdate' => 'crdate',
             'cruser_id' => 'cruser_id',
-            'dividers2tabs' => true,
             'default_sortby' => 'crdate DESC',
 
             'delete' => 'deleted',


### PR DESCRIPTION
# New Pull Request checklist

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [ ] [BUGFIX] - A bug fix
- [x] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Description
<!-- Please add a context and reasoning around your changes, to help us merge quickly. -->

This option was removed with TYPO3 v7.0 and can safely be removed.

See: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/7.0/Breaking-62833-Dividers2Tabs.html