### PR TITLE
[TASK] Introduce a new signal "removedFeedItem"

### DIFF
--- a/Classes/Feed/Update/BaseUpdater.php
+++ b/Classes/Feed/Update/BaseUpdater.php
@@ -65,7 +65,11 @@ abstract class BaseUpdater implements FeedUpdaterInterface
         if (count($this->feeds) > 0) {
             /** @var Feed $feedToRemove */
             foreach ($this->feedRepository->findNotInStorage($this->feeds, $configuration) as $feedToRemove) {
+                // todo: remove in next major version
+                /** @deprecated The call to changedFeedItem is deprecated and will be removed in version 4 */
                 $this->getSignalSlotDispatcher()->dispatch(__CLASS__, 'changedFeedItem', [$feedToRemove]);
+
+                $this->getSignalSlotDispatcher()->dispatch(__CLASS__, 'removedFeedItem', [$feedToRemove]);
                 $this->feedRepository->remove($feedToRemove);
             }
         }


### PR DESCRIPTION
# New Pull Request checklist

## PR Type

What kind of change does this PR introduce?

- [x] [FEATURE] - A new feature
- [ ] [BUGFIX] - A bug fix
- [ ] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Description

A new signal `removedFeedItem` is introduced in the `cleanUp` task.

Actually the signal name is the same when a feed item is removed or changed, and there is no way to know the type of action in the slot.

In order to not break any implementation, the new signal is added in the `cleanUp` task, in addition to the signal `changedFeedItem`, which is now deprecated.
The dispatching of `changedFeedItem` in the `cleanUp` task can be removed in the next major version.

Fixes #138
