### PR TITLE
Allow to disable import configuration

### DIFF
--- a/Classes/Controller/AdministrationController.php
+++ b/Classes/Controller/AdministrationController.php
@@ -329,7 +329,11 @@ class AdministrationController extends ActionController
     public function runConfigurationAction(Configuration $configuration)
     {
         $importService = GeneralUtility::makeInstance(ImportFeedsTaskService::class);
-        $importService->import([$configuration->getUid()]);
+        try {
+            $importService->import([ $configuration->getUid() ]);
+        } catch (\Exception $e) {
+            $this->redirectToIndex($e->getMessage(), FlashMessage::ERROR);
+        }
 
         $this->redirectToIndex($this->translate('single_import_end'));
     }

--- a/Classes/Domain/Model/Configuration.php
+++ b/Classes/Domain/Model/Configuration.php
@@ -46,6 +46,13 @@ class Configuration extends AbstractEntity
     protected $pid = 0;
 
     /**
+     * hidden
+     *
+     * @var bool
+     */
+    protected $hidden = false;
+
+    /**
      * name
      *
      * @var string
@@ -94,6 +101,22 @@ class Configuration extends AbstractEntity
     public function __construct()
     {
         $this->beGroup = new ObjectStorage();
+    }
+
+    /**
+     * @return bool
+     */
+    public function isHidden(): bool
+    {
+        return $this->hidden;
+    }
+
+    /**
+     * @param bool $hidden
+     */
+    public function setHidden(bool $hidden): void
+    {
+        $this->hidden = $hidden;
     }
 
     /**

--- a/Classes/Service/Task/ImportFeedsTaskService.php
+++ b/Classes/Service/Task/ImportFeedsTaskService.php
@@ -68,6 +68,9 @@ class ImportFeedsTaskService
             : $this->configurationRepository->findByUids($configurationUids);
 
         foreach ($configurations as $configuration) {
+            if ($configuration->isHidden()) {
+                continue;
+            }
             if (null == $token = $configuration->getToken()) {
                 continue;
             }

--- a/Classes/Service/Task/ImportFeedsTaskService.php
+++ b/Classes/Service/Task/ImportFeedsTaskService.php
@@ -7,6 +7,7 @@ use Pixelant\PxaSocialFeed\Domain\Model\Configuration;
 use Pixelant\PxaSocialFeed\Domain\Model\Token;
 use Pixelant\PxaSocialFeed\Domain\Repository\ConfigurationRepository;
 use Pixelant\PxaSocialFeed\Exception\FailedExecutingImportException;
+use Pixelant\PxaSocialFeed\Exception\InvalidFeedSourceData;
 use Pixelant\PxaSocialFeed\Exception\UnsupportedTokenType;
 use Pixelant\PxaSocialFeed\Feed\FacebookFeedFactory;
 use Pixelant\PxaSocialFeed\Feed\FeedFactoryInterface;
@@ -15,8 +16,10 @@ use Pixelant\PxaSocialFeed\Feed\TwitterFactory;
 use Pixelant\PxaSocialFeed\Feed\YoutubeFactory;
 use Pixelant\PxaSocialFeed\Service\Expire\FacebookAccessTokenExpireService;
 use Pixelant\PxaSocialFeed\Service\Notification\NotificationService;
+use Pixelant\PxaSocialFeed\Utility\ConfigurationUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
+use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 /**
@@ -42,6 +45,11 @@ class ImportFeedsTaskService
     protected $notificationService = null;
 
     /**
+     * @var PersistenceManager
+     */
+    protected $persistenceManager;
+
+    /**
      * TaskUtility constructor.
      * @param NotificationService $notificationService
      */
@@ -51,6 +59,8 @@ class ImportFeedsTaskService
 
         $this->objectManager = GeneralUtility::makeInstance(ObjectManager::class);
         $this->configurationRepository = $this->objectManager->get(ConfigurationRepository::class);
+
+        $this->persistenceManager = $this->objectManager->get(PersistenceManager::class);
     }
 
     /**
@@ -67,6 +77,7 @@ class ImportFeedsTaskService
             ? $this->configurationRepository->findAll()
             : $this->configurationRepository->findByUids($configurationUids);
 
+        $errors = [];
         foreach ($configurations as $configuration) {
             if ($configuration->isHidden()) {
                 continue;
@@ -80,16 +91,21 @@ class ImportFeedsTaskService
             try {
                 $this->importFeed($factory, $configuration);
             } catch (\Exception $exception) {
-                throw new FailedExecutingImportException(
-                    sprintf(
-                        'Failed importing using configuration "%s (UID-%d)" with message "%s"',
-                        $configuration->getName(),
-                        $configuration->getUid(),
-                        $exception->getMessage()
-                    ),
-                    1586153059241
+                $errors[] = sprintf(
+                    'Failed importing using configuration "%s (UID-%d)" with message "%s"',
+                    $configuration->getName(),
+                    $configuration->getUid(),
+                    $exception->getMessage()
                 );
+                $this->disableConfiguration($configuration);
             }
+        }
+
+        if ($errors !== []) {
+            throw new FailedExecutingImportException(
+                implode(PHP_EOL, $errors),
+                1586153059241
+            );
         }
 
         return true;
@@ -177,5 +193,23 @@ class ImportFeedsTaskService
                 )
             );
         }
+    }
+
+    /**
+     * Disable a configuration, if feature enabled
+     *
+     * @param Configuration $configuration
+     * @return void
+     */
+    protected function disableConfiguration(Configuration $configuration): void
+    {
+        $extConf = ConfigurationUtility::getExtensionConfiguration();
+        if (!($extConf['disableConfigurationOnFailure'] ?? false)) {
+            return;
+        }
+
+        $configuration->setHidden(true);
+        $this->configurationRepository->update($configuration);
+        $this->persistenceManager->persistAll();
     }
 }

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -96,6 +96,9 @@
             <trans-unit id="module.image_size">
                 <source>Image Size</source>
             </trans-unit>
+            <trans-unit id="module.hidden">
+                <source>Disabled</source>
+            </trans-unit>
             <trans-unit id="module.generate_access_token">
                 <source>Login to Facebook and get access token</source>
             </trans-unit>

--- a/Resources/Private/Partials/Backend/ListConfigurations.html
+++ b/Resources/Private/Partials/Backend/ListConfigurations.html
@@ -18,7 +18,11 @@
 
                     <f:for each="{configurations}" as="configuration">
                         <tr>
-                            <td>{configuration.uid}</td>
+                            <td>
+                                <span title="id={configuration.uid}">
+                                    <core:icon identifier="ext-pxasocialfeed-model-icon" overlay="{f:if(condition: configuration.hidden, then: 'overlay-hidden')}" state="{f:if(condition: configuration.hidden, then: 'disabled', else: 'default')}" />
+                                </span>
+                            </td>
                             <td>{configuration.name}</td>
                             <td>{configuration.socialId}</td>
                             <td>{configuration.maxItems}</td>
@@ -27,9 +31,18 @@
                             <td>
                                 <div class="btn-group">
                                     <f:if condition="{isAdmin}">
-                                        <f:link.action action="runConfiguration" class="btn btn-default" arguments="{configuration: configuration}" title="{f:translate(key: 'module.execute_single_import')}">
-                                            <core:icon identifier="actions-play" />
-                                        </f:link.action>
+                                        <f:if condition="!{configuration.hidden}">
+                                            <f:then>
+                                                <f:link.action action="runConfiguration" class="btn btn-default" arguments="{configuration: configuration}" title="{f:translate(key: 'module.execute_single_import')}">
+                                                    <core:icon identifier="actions-play" />
+                                                </f:link.action>
+                                            </f:then>
+                                            <f:else>
+                                                <span class="btn btn-default disabled" aria-hidden="true">
+                                                    <core:icon identifier="empty-empty" />
+                                                </span>
+                                            </f:else>
+                                        </f:if>
                                     </f:if>
 
                                     <f:link.action action="editConfiguration" class="btn btn-default" arguments="{configuration: configuration}" title="{f:translate(key: 'module.edit')}">

--- a/Resources/Private/Templates/Administration/EditConfiguration.html
+++ b/Resources/Private/Templates/Administration/EditConfiguration.html
@@ -65,6 +65,10 @@
                         <td><f:translate key="module.image_size"/></td>
                         <td><f:form.select property="imageSize" options="{normal_images: 'Normal Images', small_images: 'Small Images'}" class="form-control"/></td>
                       </tr>
+                      <tr>
+                        <td><f:translate key="module.hidden"/></td>
+                        <td><f:form.checkbox property="hidden" value="1" class="form-check-input"/></td>
+                      </tr>
 
                         <f:render partial="Backend/Form/BeGroupsSelect" arguments="{beGroups: beGroups}" />
                         <tr>

--- a/Tests/Unit/Domain/Model/ConfigurationTest.php
+++ b/Tests/Unit/Domain/Model/ConfigurationTest.php
@@ -76,6 +76,25 @@ class ConfigurationTest extends UnitTestCase
     /**
      * @test
      */
+    public function initialValueOfHidden()
+    {
+        $this->assertEquals(false, $this->subject->isHidden());
+    }
+
+    /**
+     * @test
+     */
+    public function canSetHidden()
+    {
+        $value = true;
+
+        $this->subject->setHidden($value);
+        $this->assertEquals($value, $this->subject->isHidden());
+    }
+
+    /**
+     * @test
+     */
     public function initialValueOfName()
     {
         $this->assertEquals('', $this->subject->getName());

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -6,3 +6,6 @@ editorRestrictionIsRequired = 0
 
 # cat=basic/enable/150; type=string; label=Exclude backend user groups from selection
 excludeBackendUserGroups =
+
+# cat=basic/enable/200; type=boolean; label=Disable configuration if the feed import task failed
+disableConfigurationOnFailure = 0

--- a/ext_typoscript_setup.txt
+++ b/ext_typoscript_setup.txt
@@ -1,0 +1,6 @@
+plugin.tx_pxasocialfeed {
+    features {
+        ignoreAllEnableFieldsInBe = 1
+    }
+}
+module.tx_pxasocialfeed < plugin.tx_pxasocialfeed


### PR DESCRIPTION
# New Pull Request checklist

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [x] [FEATURE] - A new feature
- [ ] [BUGFIX] - A bug fix
- [ ] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Description

This PR allows to set the disabled state of an import configuration.
The disabled state can be set on the BE module form, and can be seen in the list of configurations.

Also, the disabled state is taken into account during the scheduler task run: disabled configurations are ignored.

A new feature flag (in extension configuration) is added to auto-disable configuration during an import, if an exception occured.

And, finally, a failed import does not stop the loop anymore, the remaining configurations to be imported are processed.
The scheduler task fails only if at least one exception was thrown.