### PR TITLE
[BUGFIX] Use $token->getParentToken in constraint instead of $token

### DIFF
--- a/Classes/Domain/Repository/TokenRepository.php
+++ b/Classes/Domain/Repository/TokenRepository.php
@@ -60,7 +60,7 @@ class TokenRepository extends AbstractBackendRepository
 
         $query->matching(
             $query->logicalAnd([
-                $query->equals('parentToken', $token),
+                $query->equals('parentToken', $token->getParentToken()),
                 $query->equals('fbSocialId', $fbSocialId)
             ])
         );


### PR DESCRIPTION
# New Pull Request checklist

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [x] [BUGFIX] - A bug fix

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Description
Hi,  
Whenever I would try to run the import, this error would show up

![image](https://user-images.githubusercontent.com/39330651/228261028-2c80b11f-bc6f-4fb7-bb3a-1a71dcb48ba1.png)

This is due to the fact that when you try to retrieve the FB Page token in the `TokenRepository` the first constraint seems to be incorrect.

