### PR TITLE
[BUGFIX] Prevent annotation error on $parentToken

### DIFF
--- a/Classes/Domain/Model/Token.php
+++ b/Classes/Domain/Model/Token.php
@@ -134,11 +134,9 @@ class Token extends AbstractEntity
     protected string $fbSocialId = '';
 
     /**
-     * @TYPO3\CMS\Extbase\Annotation\ORM\Lazy
-     *
-     * @var null|LazyLoadingProxy|Token
+     * @var null|Token
      */
-    protected $parentToken;
+    protected $parentToken = null;
 
     /**
      * Initialize.
@@ -423,9 +421,6 @@ class Token extends AbstractEntity
      */
     public function getParentToken(): ?Token
     {
-        if ($this->parentToken instanceof LazyLoadingProxy) {
-            $this->parentToken->_loadRealInstance();
-        }
         if ($this->parentToken instanceof Token) {
             return $this->parentToken;
         }


### PR DESCRIPTION
Tasks:
* Remove the notion of LazyLoading
* Prevent the error related to the phpdoc annotation

# New Pull Request checklist

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [x] [BUGFIX] - A bug fix

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Description
<!-- Please add a context and reasoning around your changes, to help us merge quickly. -->
Hi, 
I create this pull request to fix an issue I have on my TYPO3 10 website when I click on the Social Feed module. It seems like the PHPDoc annotation you have for the $parentToken is the issue.

Here is the error I had :  

![image](https://user-images.githubusercontent.com/39330651/228466067-6960e3da-04cb-4d19-921a-41efe7131051.png)
 
Since the issue was the lazyloading I removed it, what do you think ?