### PR TITLE
[TASK] Check http error code before disable a configuration

### DIFF
--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -9,3 +9,6 @@ excludeBackendUserGroups =
 
 # cat=basic/enable/200; type=boolean; label=Disable configuration if the feed import task failed
 disableConfigurationOnFailure = 0
+
+# cat=basic/enable/200; type=boolean; label=List of http error codes that can disable configuration (if empty, error code is not checked)
+disableConfigurationOnFailureErrorCodes = 403,404


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [ ] [BUGFIX] - A bug fix
- [x] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Description

A new extension setting allows to list which http error code can disable a configuration when an error occured.

By default, a configuration will be disabled if a 403 or 404 http error occurred.

This allows temporary errors like timeouts or maintenance to not disable configuration.
